### PR TITLE
Added menu option to clear Gulp Output console

### DIFF
--- a/main.js
+++ b/main.js
@@ -94,6 +94,10 @@ define(function (require, exports, module) {
             }
 			this.elem.append('<p>' + output + '</p>');
 			this.elem[0].scrollTop = this.elem[0].scrollHeight;
+		},
+		clear: function () {
+			if (this.elem)
+				this.elem.html('');
 		}
 	};
 
@@ -125,11 +129,17 @@ define(function (require, exports, module) {
 						defaultTitle = 'Default'; defaultTask = '';
 					}
 					CommandManager.register(defaultTitle, 'djb.brackets-gulp.gulp', function () {
-							gulpDomain.exec('gulp', defaultTask, gulpRoot, false);
-						});
-
+						gulpDomain.exec('gulp', defaultTask, gulpRoot, false);
+					});
 				}
 				gulpMenu.addMenuItem('djb.brackets-gulp.gulp', 'Alt-G');
+				gulpMenu.addMenuDivider();
+			}
+			if (!Menus.getMenuItem('djb.brackets-gulp.clear')) {
+				if (!CommandManager.get('djb.brackets-gulp.clear')) {
+					CommandManager.register('Clear Gulp Output console', 'djb.brackets-gulp.clear', formOutput.clear.bind(formOutput));
+				}
+				gulpMenu.addMenuItem('djb.brackets-gulp.clear');
 				gulpMenu.addMenuDivider();
 			}
 			gulpDomain.exec('gulp', '--tasks-simple', gulpRoot, false);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dalcib.brackets-gulp",
   "title": "Brackets-Gulp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Adds Gulp.js support to Brackets.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a menu item titled "Clear Gulp Output console" between the default task and the tasks found in gulpfile.js. The menu item does just what it says - it clears the Gulp Output console window.